### PR TITLE
Fix deb-utils build

### DIFF
--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -87,7 +87,7 @@
 %define __python                  %{__use_python}
 %define __python_pkg_version      %{__use_python_pkg_version}
 %endif
-%define __python_sitelib          %(%{__python} -Esc "from distutils.sysconfig import get_python_lib; print(get_python_lib())" 2>/dev/null || %{__python} -Esc "import sysconfig; print(sysconfig.get_path('purelib'))")
+%define __python_sitelib          %{_prefix}/%(echo -n @pythondir@)
 
 Name:           @PACKAGE@
 Version:        @VERSION@


### PR DESCRIPTION
This PR fixes an issue in the deb-utils build that prevents building packages on debian-derived distributions.