### PR TITLE
Allow ZFS to build on Ubuntu 18.04.

### DIFF
--- a/config/kernel-blkdev.m4
+++ b/config/kernel-blkdev.m4
@@ -396,6 +396,7 @@ AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_INVALIDATE_BDEV], [
 dnl #
 dnl # 5.11 API, lookup_bdev() takes dev_t argument.
 dnl # 2.6.27 API, lookup_bdev() was first exported.
+dnl # 4.4.0-6.21 API, lookup_bdev() on Ubuntu takes mode argument.
 dnl #
 AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_LOOKUP_BDEV], [
 	ZFS_LINUX_TEST_SRC([lookup_bdev_devt], [
@@ -417,6 +418,15 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_LOOKUP_BDEV], [
 
 		bdev = lookup_bdev(path);
 	])
+
+	ZFS_LINUX_TEST_SRC([lookup_bdev_mode], [
+		#include <linux/fs.h>
+	], [
+		struct block_device *bdev __attribute__ ((unused));
+		const char path[] = "/example/path";
+
+		bdev = lookup_bdev(path, FMODE_READ);
+	])
 ])
 
 AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_LOOKUP_BDEV], [
@@ -436,7 +446,17 @@ AC_DEFUN([ZFS_AC_KERNEL_BLKDEV_LOOKUP_BDEV], [
 			AC_DEFINE(HAVE_1ARG_LOOKUP_BDEV, 1,
 			    [lookup_bdev() wants 1 arg])
 		], [
-			ZFS_LINUX_TEST_ERROR([lookup_bdev()])
+			AC_MSG_RESULT(no)
+
+			AC_MSG_CHECKING([whether lookup_bdev() wants mode arg])
+			ZFS_LINUX_TEST_RESULT_SYMBOL([lookup_bdev_mode],
+			    [lookup_bdev], [fs/block_dev.c], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_MODE_LOOKUP_BDEV, 1,
+				    [lookup_bdev() wants mode arg])
+			], [
+				ZFS_LINUX_TEST_ERROR([lookup_bdev()])
+			])
 		])
 	])
 ])

--- a/include/os/linux/kernel/linux/blkdev_compat.h
+++ b/include/os/linux/kernel/linux/blkdev_compat.h
@@ -322,6 +322,9 @@ zfs_check_media_change(struct block_device *bdev)
  * The function was exported for use, prior to this it existed but the
  * symbol was not exported.
  *
+ * 4.4.0-6.21 API change for Ubuntu
+ * lookup_bdev() gained a second argument, FMODE_*, to check inode permissions.
+ *
  * 5.11 API change
  * Changed to take a dev_t argument which is set on success and return a
  * non-zero error code on failure.
@@ -333,6 +336,15 @@ vdev_lookup_bdev(const char *path, dev_t *dev)
 	return (lookup_bdev(path, dev));
 #elif defined(HAVE_1ARG_LOOKUP_BDEV)
 	struct block_device *bdev = lookup_bdev(path);
+	if (IS_ERR(bdev))
+		return (PTR_ERR(bdev));
+
+	*dev = bdev->bd_dev;
+	bdput(bdev);
+
+	return (0);
+#elif defined(HAVE_MODE_LOOKUP_BDEV)
+	struct block_device *bdev = lookup_bdev(path, FMODE_READ);
 	if (IS_ERR(bdev))
 		return (PTR_ERR(bdev));
 


### PR DESCRIPTION
Revert "config: remove HAVE_MODE_LOOKUP_BDEV"

After this commit is reverted, ZFS builds successfully on 18.04 and passes tests.