### PR TITLE
Revert "xattr dataset prop: change defaults to sa"

### DIFF
--- a/man/man7/zfsprops.7
+++ b/man/man7/zfsprops.7
@@ -1983,13 +1983,14 @@ enabled for virus scanning to occur.
 The default value is
 .Sy off .
 This property is not used by OpenZFS.
-.It Sy xattr Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy dir Ns | Ns Sy sa
+.It Sy xattr Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy sa
 Controls whether extended attributes are enabled for this file system.
 Two styles of extended attributes are supported: either directory-based
 or system-attribute-based.
 .Pp
-Directory-based extended attributes can be enabled by setting the value to
-.Sy dir .
+The default value of
+.Sy on
+enables directory-based extended attributes.
 This style of extended attribute imposes no practical limit
 on either the size or number of attributes which can be set on a file.
 Although under Linux the
@@ -2002,10 +2003,7 @@ This is the most compatible
 style of extended attribute and is supported by all ZFS implementations.
 .Pp
 System-attribute-based xattrs can be enabled by setting the value to
-.Sy sa
-(default and equal to
-.Sy on
-) .
+.Sy sa .
 The key advantage of this type of xattr is improved performance.
 Storing extended attributes as system attributes
 significantly decreases the amount of disk I/O required.

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -166,7 +166,7 @@ zfsvfs_parse_option(char *option, int token, substring_t *args, vfs_t *vfsp)
 		vfsp->vfs_do_xattr = B_TRUE;
 		break;
 	case TOKEN_XATTR:
-		vfsp->vfs_xattr = ZFS_XATTR_SA;
+		vfsp->vfs_xattr = ZFS_XATTR_DIR;
 		vfsp->vfs_do_xattr = B_TRUE;
 		break;
 	case TOKEN_NOXATTR:

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -365,7 +365,7 @@ zfs_prop_init(void)
 
 	static const zprop_index_t xattr_table[] = {
 		{ "off",	ZFS_XATTR_OFF },
-		{ "on",		ZFS_XATTR_SA },
+		{ "on",		ZFS_XATTR_DIR },
 		{ "sa",		ZFS_XATTR_SA },
 		{ "dir",	ZFS_XATTR_DIR },
 		{ NULL }
@@ -478,7 +478,7 @@ zfs_prop_init(void)
 	zprop_register_index(ZFS_PROP_LOGBIAS, "logbias", ZFS_LOGBIAS_LATENCY,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "latency | throughput", "LOGBIAS", logbias_table, sfeatures);
-	zprop_register_index(ZFS_PROP_XATTR, "xattr", ZFS_XATTR_SA,
+	zprop_register_index(ZFS_PROP_XATTR, "xattr", ZFS_XATTR_DIR,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_SNAPSHOT,
 	    "on | off | dir | sa", "XATTR", xattr_table, sfeatures);
 	zprop_register_index(ZFS_PROP_DNODESIZE, "dnodesize",

--- a/tests/zfs-tests/tests/functional/projectquota/projectid_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectid_003_pos.ksh
@@ -60,7 +60,7 @@ log_onexit cleanup
 
 log_assert "Check changing project ID with directory-based extended attributes"
 
-log_must zfs set xattr=dir $QFS
+log_must zfs set xattr=on $QFS
 
 log_must touch $PRJGUARD
 log_must chattr -p $PRJID1 $PRJGUARD
@@ -77,6 +77,6 @@ sync_pool
 typeset prj_aft=$(project_obj_count $QFS $PRJID1)
 
 [[ $prj_aft -ge $((prj_bef + 5)) ]] ||
-	log_fail "new value ($prj_aft) is NOT 5 larger than old one ($prj_bef)"
+	log_fail "new value ($prj_aft) is NOT 5 largr than old one ($prj_bef)"
 
 log_pass "Changing project ID with directory-based extended attributes pass"

--- a/tests/zfs-tests/tests/functional/xattr/xattr_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_001_pos.ksh
@@ -53,7 +53,7 @@ function cleanup {
 	fi
 }
 
-set -A args "dir" "sa"
+set -A args "on" "sa"
 
 log_assert "Create/read/write/append of xattrs works"
 log_onexit cleanup

--- a/tests/zfs-tests/tests/functional/xattr/xattr_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/xattr/xattr_002_neg.ksh
@@ -47,7 +47,7 @@ function cleanup {
 
 }
 
-set -A args "dir" "sa"
+set -A args "on" "sa"
 
 log_assert "A read of a non-existent xattr fails"
 log_onexit cleanup


### PR DESCRIPTION
This reverts commit e419a63bf4cd6abb58e392b4341a8057c4481dba.

The upstream commit changed the default from `dir` to `sa`, so the value of `on` now means `sa` where it previously meant `dir`. However, due to the way they did this, setting it explicitly to `sa` returns a value of `on` instead of `sa` as it should.

We are drafting a patch and working with upstream to solve the issue, but in the team time, this small change will avoid the issue during Wasabi testing.
