### PR TITLE
ZIL: only defer flushes when next LWB has in-flight ZIO

### DIFF
--- a/META
+++ b/META
@@ -2,7 +2,7 @@ Meta:          1
 Name:          zfs
 Branch:        1.0
 Version:       2.1.5.9
-Release:       2wasabi0
+Release:       3wasabi0
 Release-Tags:  relext
 License:       CDDL
 Author:        OpenZFS

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -454,6 +454,11 @@ typedef struct zil_stats {
 	 */
 	kstat_named_t zil_itx_metaslab_slog_count;
 	kstat_named_t zil_itx_metaslab_slog_bytes;
+
+	kstat_named_t zil_lwb_open_count;
+	kstat_named_t zil_lwb_chain_count;
+	kstat_named_t zil_lwb_chain_write_count;
+	kstat_named_t zil_lwb_defer_flush_count;
 } zil_stats_t;
 
 extern zil_stats_t zil_stats;

--- a/include/sys/zil_impl.h
+++ b/include/sys/zil_impl.h
@@ -106,6 +106,7 @@ typedef struct lwb {
 	list_t		lwb_waiters;	/* list of zil_commit_waiter's */
 	avl_tree_t	lwb_vdev_tree;	/* vdevs to flush after lwb write */
 	hrtime_t	lwb_issued_timestamp; /* when was the lwb issued? */
+	boolean_t	lwb_can_defer;	/* true if flush can be deferred */
 } lwb_t;
 
 /*


### PR DESCRIPTION
Includes:
* actual race work around
* kstats and tunable for LWB write chain and flush defer study
* additional commits which are present in the `zfs-2.1.5.9-3wasabi0` _tag_, but not in the _branch_, which is all I can create a PR against

Refer to report for details.