### PR TITLE
ZIL: kstats and tunable for LWB write chain and flush defer study

### DIFF
--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -544,6 +544,11 @@ typedef struct zil_stats {
 	kstat_named_t zil_itx_metaslab_slog_bytes;
 	kstat_named_t zil_itx_metaslab_slog_write;
 	kstat_named_t zil_itx_metaslab_slog_alloc;
+
+	kstat_named_t zil_lwb_open_count;
+	kstat_named_t zil_lwb_chain_count;
+	kstat_named_t zil_lwb_chain_write_count;
+	kstat_named_t zil_lwb_defer_flush_count;
 } zil_kstat_values_t;
 
 typedef struct zil_sums {
@@ -568,6 +573,10 @@ typedef struct zil_sums {
 	wmsum_t zil_itx_metaslab_slog_bytes;
 	wmsum_t zil_itx_metaslab_slog_write;
 	wmsum_t zil_itx_metaslab_slog_alloc;
+	wmsum_t zil_lwb_open_count;
+	wmsum_t zil_lwb_chain_count;
+	wmsum_t zil_lwb_chain_write_count;
+	wmsum_t zil_lwb_defer_flush_count;
 } zil_sums_t;
 
 #define	ZIL_STAT_INCR(zil, stat, val) \

--- a/module/zfs/dataset_kstats.c
+++ b/module/zfs/dataset_kstats.c
@@ -59,7 +59,11 @@ static dataset_kstat_values_t empty_dataset_kstats = {
 	{ "zil_itx_metaslab_slog_count",	KSTAT_DATA_UINT64 },
 	{ "zil_itx_metaslab_slog_bytes",	KSTAT_DATA_UINT64 },
 	{ "zil_itx_metaslab_slog_write",	KSTAT_DATA_UINT64 },
-	{ "zil_itx_metaslab_slog_alloc",	KSTAT_DATA_UINT64 }
+	{ "zil_itx_metaslab_slog_alloc",	KSTAT_DATA_UINT64 },
+	{ "zil_lwb_open_count",			KSTAT_DATA_UINT64 },
+	{ "zil_lwb_chain_count",		KSTAT_DATA_UINT64 },
+	{ "zil_lwb_chain_write_count",		KSTAT_DATA_UINT64 },
+	{ "zil_lwb_defer_flush_count",		KSTAT_DATA_UINT64 },
 	}
 };
 


### PR DESCRIPTION
Same kstats and tunable from #24, but for 2.3.2-wasabi.

No additional patch necessary, refer to report for details.