### PR TITLE
Don't fix errors when detected

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -7991,8 +7991,9 @@ print_error_log(zpool_handle_t *zhp, int verbosity)
 {
 	nvlist_t *nverrlist = NULL;
 	nvpair_t *elem;
-	char *pathname;
+	char *pathname, *last_pathname = NULL;
 	size_t len = MAXPATHLEN * 2;
+	boolean_t started = B_FALSE;
 
 	if (zpool_get_errlog(zhp, &nverrlist, verbosity) != 0)
 		return;
@@ -8012,12 +8013,25 @@ print_error_log(zpool_handle_t *zhp, int verbosity)
 		verify(nvlist_lookup_uint64(nv, ZPOOL_ERR_OBJECT,
 		    &obj) == 0);
 		zpool_obj_to_path(zhp, dsobj, obj, pathname, len);
+		if (last_pathname == NULL ||
+		    0 != strncmp(pathname, last_pathname, len))
+		{
+			last_pathname = strdup(pathname);
+			if (started)
+				(void) printf("\n");
+			else
+				started = B_TRUE;
+			(void) printf("%7s %s ", "", pathname);
+		} else if (verbosity > 1) {
+			(void) printf(",");
+		}
 		if (verbosity > 1) {
 			uint64_t level, blkid, blkid_next, blkid_start;
 
 			blkid = fnvlist_lookup_uint64(nv, ZPOOL_ERR_BLKID);
 			blkid_start = blkid;
 			level = fnvlist_lookup_uint64(nv, ZPOOL_ERR_LEVEL);
+			(void) printf("L%lu=", level);
 			do {
 				uint64_t level_next;
 				uint64_t dsobj_next, obj_next;
@@ -8050,16 +8064,14 @@ print_error_log(zpool_handle_t *zhp, int verbosity)
 			} while(1) ;
 
 			if (blkid > blkid_start)
-				(void) printf("%7s %s L%lu=%lu-%lu\n", "",
-				    pathname, level, blkid_start, blkid);
+				(void) printf("%lu-%lu", blkid_start, blkid);
 			else
-				(void) printf("%7s %s L%lu=%lu\n", "", pathname,
-				    level, blkid);
-		} else {
-			(void) printf("%7s %s\n", "", pathname);
+				(void) printf("%lu", blkid);
 		}
 	}
+	(void) printf("\n");
 	free(pathname);
+	free(last_pathname);
 	nvlist_free(nverrlist);
 }
 

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -414,7 +414,7 @@ extern zpool_status_t zpool_import_status(nvlist_t *, char **,
 extern nvlist_t *zpool_get_config(zpool_handle_t *, nvlist_t **);
 extern nvlist_t *zpool_get_features(zpool_handle_t *);
 extern int zpool_refresh_stats(zpool_handle_t *, boolean_t *);
-extern int zpool_get_errlog(zpool_handle_t *, nvlist_t **);
+extern int zpool_get_errlog(zpool_handle_t *, nvlist_t **, int);
 
 /*
  * Import and export functions

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1450,6 +1450,8 @@ typedef enum {
 #define	ZPOOL_ERR_LIST		"error list"
 #define	ZPOOL_ERR_DATASET	"dataset"
 #define	ZPOOL_ERR_OBJECT	"object"
+#define	ZPOOL_ERR_LEVEL		"level"
+#define	ZPOOL_ERR_BLKID		"blkid"
 
 #define	HIS_MAX_RECORD_LEN	(MAXPATHLEN + MAXPATHLEN + 1)
 

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -5941,6 +5941,7 @@
     <function-decl name='zpool_get_errlog' mangled-name='zpool_get_errlog' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_get_errlog'>
       <parameter type-id='4c81de99' name='zhp'/>
       <parameter type-id='857bb57e' name='nverrlistp'/>
+      <parameter type-id='95e97e5e' name='verbosity'/>
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='zpool_upgrade' mangled-name='zpool_upgrade' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zpool_upgrade'>

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4228,7 +4228,7 @@ zbookmark_mem_compare(const void *a, const void *b)
  * caller.
  */
 int
-zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
+zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp, int verbosity)
 {
 	zfs_cmd_t zc = {"\0"};
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
@@ -4291,8 +4291,16 @@ zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
 	for (i = 0; i < count; i++) {
 		nvlist_t *nv;
 
-		/* ignoring zb_blkid and zb_level for now */
+		/* filter out duplicate records */
 		if (i > 0 && zb[i-1].zb_objset == zb[i].zb_objset &&
+		    zb[i-1].zb_object == zb[i].zb_object &&
+		    zb[i-1].zb_level == zb[i].zb_level &&
+		    zb[i-1].zb_blkid == zb[i].zb_blkid)
+			continue;
+
+		/* filter out duplicate files */
+		if (verbosity < 2 && i > 0 &&
+		    zb[i-1].zb_objset == zb[i].zb_objset &&
 		    zb[i-1].zb_object == zb[i].zb_object)
 			continue;
 
@@ -4307,6 +4315,18 @@ zpool_get_errlog(zpool_handle_t *zhp, nvlist_t **nverrlistp)
 		    zb[i].zb_object) != 0) {
 			nvlist_free(nv);
 			goto nomem;
+		}
+		if (verbosity > 1) {
+			if (nvlist_add_uint64(nv, ZPOOL_ERR_LEVEL,
+			    zb[i].zb_level) != 0) {
+				nvlist_free(nv);
+				goto nomem;
+			}
+			if (nvlist_add_uint64(nv, ZPOOL_ERR_BLKID,
+			    zb[i].zb_blkid) != 0) {
+				nvlist_free(nv);
+				goto nomem;
+			}
 		}
 		if (nvlist_add_nvlist(*nverrlistp, "ejk", nv) != 0) {
 			nvlist_free(nv);

--- a/man/man8/zpool-status.8
+++ b/man/man8/zpool-status.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd June 2, 2021
+.Dd July 1, 2025
 .Dt ZPOOL-STATUS 8
 .Os
 .
@@ -117,7 +117,9 @@ See
 .Xr date 1 .
 .It Fl v
 Displays verbose data error information, printing out a complete list of all
-data errors since the last complete pool scrub.
+files containing data errors since the last complete pool scrub.
+Specified twice, prints out the complete list of all corrupt records within
+each corrupt file.
 .It Fl x
 Only display status for pools that are exhibiting errors or are otherwise
 unavailable.


### PR DESCRIPTION
This PR strips out the logic that repairs erorrs using known-good copies of the data (for mirrors and metadata blocks that are stored redundantly) or parity (using raidz). This should cause errors to persist after a scrub, and still be present.

The upstream PR that reports error offsets with `zpool status -vv` has also been included.