### PR TITLE
zdb: Add -O option for -r to specify object-id

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -709,13 +709,14 @@ usage(void)
 	    "[-U <cache>]\n\t\t<poolname> [<vdev> [<metaslab> ...]]\n"
 	    "\t%s -O [-K <key>] <dataset> <path>\n"
 	    "\t%s -r [-K <key>] <dataset> <path> <destination>\n"
+	    "\t%s -r [-K <key>] -O <dataset> <object-id> <destination>\n"
 	    "\t%s -R [-A] [-e [-V] [-p <path> ...]] [-U <cache>]\n"
 	    "\t\t<poolname> <vdev>:<offset>:<size>[:<flags>]\n"
 	    "\t%s -E [-A] word0:word1:...:word15\n"
 	    "\t%s -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] "
 	    "<poolname>\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname,
-	    cmdname, cmdname, cmdname, cmdname, cmdname);
+	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname);
 
 	(void) fprintf(stderr, "    Dataset name must include at least one "
 	    "separator character '/' or '@'\n");
@@ -9667,7 +9668,7 @@ main(int argc, char **argv)
 	 * which imports the pool to the namespace if it's
 	 * not in the cachefile.
 	 */
-	if (dump_opt['O']) {
+	if (dump_opt['O'] && !dump_opt['r']) {
 		if (argc != 2)
 			usage();
 		dump_opt['v'] = verbose + 3;
@@ -9680,7 +9681,11 @@ main(int argc, char **argv)
 		if (argc != 3)
 			usage();
 		dump_opt['v'] = verbose;
-		error = dump_path(argv[0], argv[1], &object);
+		if (dump_opt['O']) {
+			object = strtoull(argv[1], NULL, 0);
+		} else {
+			error = dump_path(argv[0], argv[1], &object);
+		}
 		if (error != 0)
 			fatal("internal error: %s", strerror(error));
 	}

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -77,6 +77,11 @@
 .Op Fl K Ar key
 .Ar dataset path destination
 .Nm
+.Fl r
+.Fl O
+.Op Fl K Ar key
+.Ar dataset object-id destination
+.Nm
 .Fl R
 .Op Fl A
 .Op Fl e Oo Fl V Oc Oo Fl p Ar path Oc Ns …
@@ -350,6 +355,12 @@ Specified
 .Ar path
 must be relative to the root of
 .Ar dataset .
+When used with
+.Fl O ,
+the
+.Ar path
+argument is interpreted as an object identifier,
+not a path.
 This option can be combined with
 .Fl v
 for increasing verbosity.


### PR DESCRIPTION
"zdb -r -O pool/dataset obj-id destination" will copy the file with object-id obj-id to the named destination; without -O it'll still be interpreted as a pathname.

Sponsored-by: Klara, Inc.
Sponsored-by: Wasabi Technology, Inc.
Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Akash B <akash-b@hpe.com>

Closes #16307
(cherry picked from commit 1d43387dd8e26b5b304562263b61f52d4d7bde91)
