### PR TITLE
Make sure we can still write data to txg

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2132,6 +2132,9 @@ spa_sync_time_logger(spa_t *spa, uint64_t txg)
 	if (curtime < spa->spa_last_flush_txg_time + spa_flush_txg_time) {
 		return;
 	}
+	if (txg > spa_final_dirty_txg(spa)) {
+		return;
+	}
 	spa->spa_last_flush_txg_time = curtime;
 
 	tx = dmu_tx_create_assigned(spa_get_dsl(spa), txg);


### PR DESCRIPTION
The final txgs are used only to clear out any remaining deferred frees, and we cannot write new data to them. Make sure we do not try to do so.