### PR TITLE
2.3.2.5 patchset

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2712,18 +2712,18 @@ print_file_layout_raidz(vdev_t *vd, blkptr_t *bp, uint64_t file_offset,
 	    vd->vdev_children, vdrz->vd_nparity);
 	raidz_row_t *rr = rm->rm_row[0];
 
-	/*
-	 * Account for out of order disks in raidz1.
-	 * For now just reverse them back and adjust for it later.
-	 */
-	if (rr->rr_firstdatacol == 1 && (zio.io_offset & (1ULL << 20))) {
-		uint64_t devidx = rr->rr_col[0].rc_devidx;
-		rr->rr_col[0].rc_devidx = rr->rr_col[1].rc_devidx;
-		rr->rr_col[1].rc_devidx = devidx;
-	}
-
 	if (!dump_opt['H']) {
 		int last_disk = vd->vdev_children - 1;
+		/*
+		 * Account for out of order disks in raidz1.
+		 * For now just reverse them back and adjust for it later.
+		 */
+		if (rr->rr_firstdatacol == 1 &&
+		    (zio.io_offset & (1ULL << 20))) {
+			uint64_t devidx = rr->rr_col[0].rc_devidx;
+			rr->rr_col[0].rc_devidx = rr->rr_col[1].rc_devidx;
+			rr->rr_col[1].rc_devidx = devidx;
+		}
 		int first_disk = rr->rr_col[0].rc_devidx;
 
 		(void) printf("%12llx", (u_longlong_t)file_offset);
@@ -2753,23 +2753,49 @@ print_file_layout_raidz(vdev_t *vd, blkptr_t *bp, uint64_t file_offset,
 		static uint64_t next_offset = 0;
 
 		if (next_offset != file_offset) {
-			(void) printf("skip hole\t-\t%llx\n",
-			    (u_longlong_t)((file_offset - next_offset) >>
-			    vd->vdev_ashift));
+			(void) printf("skip hole\t-\t\t%lld\n",
+			    (u_longlong_t)((file_offset - next_offset) / 512));
 		}
 		next_offset = file_offset + BP_GET_LSIZE(bp);
+		uint64_t tmp_offset = file_offset;
+
 
 		for (int c = 0; c < rr->rr_cols; c++) {
+			boolean_t pcol = c < rr->rr_firstdatacol;
 			raidz_col_t *rc = &rr->rr_col[c];
 			char *path = vd->vdev_child[rc->rc_devidx]->vdev_path;
-			// c < rr->rr_firstdatacol
+
 			if (rc->rc_size == 0)
 				continue;
-			(void) printf("%s\t%llu\t%d\n",
+			(void) printf("%s\t\t%llu\t%d",
 			    zfs_basename(path),
 			    (u_longlong_t)(rc->rc_offset +
 			    VDEV_LABEL_START_SIZE)/512,
 			    (int)rc->rc_size/512);
+			if (dump_opt['v']) {
+				char label = pcol ? 'P' : 'D';
+				int num;
+
+				if (c < 2) {
+					num = 0;
+				} else {
+					num = pcol ? c :
+					    (c - rr->rr_firstdatacol);
+				}
+				printf("\t%c%d", label, num);
+				if (dump_opt['v'] > 1) {
+					unsigned long long off;
+					if (pcol)
+						off = file_offset;
+					else
+						off = tmp_offset;
+					off = off / 512ULL;
+					printf("\t%llu", off);
+				}
+			}
+			if (!pcol)
+				tmp_offset += rc->rc_size;
+			printf("\n");
 		}
 	}
 }
@@ -2891,7 +2917,12 @@ dump_indirect_layout(dnode_t *dn)
 	 * Start layout with a header
 	 */
 	if (dump_opt['H']) {
-		(void) printf("DISK\t\tLBA\t\tCOUNT\n");
+		(void) printf("DISK\t\t\tLBA\tCOUNT");
+		if (dump_opt['v'])
+			(void) printf("\tTYPE");
+		if (dump_opt['v'] > 1)
+			(void) printf("\tOFFSET");
+		printf("\n");
 	} else {
 		char diskhdr[16];
 
@@ -10203,6 +10234,7 @@ retry_lookup:
 		}
 
 		if (dump_opt['f'] && os != NULL) {
+			dump_opt['v'] = verbose;
 			dump_file_data_layout(os);
 		} else if (dump_opt['B']) {
 			dump_backup(target, objset_id,

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -720,7 +720,7 @@ usage(void)
 	    "\t%s -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] "
 	    "<poolname>\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname,
-	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname);
+	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname);
 
 	(void) fprintf(stderr, "    Dataset name must include at least one "
 	    "separator character '/' or '@'\n");
@@ -2783,7 +2783,9 @@ print_file_layout(spa_t *spa, blkptr_t *bp, const zbookmark_phys_t *zb,
 		ASSERT3U(BP_GET_LEVEL(bp), ==, zb->zb_level);
 	}
 	ASSERT(zb->zb_level >= 0);
-	ASSERT0(BP_IS_HOLE(bp));
+
+	if (BP_IS_HOLE(bp))
+		return;
 
 	if (BP_IS_EMBEDDED(bp))
 		return;
@@ -9804,7 +9806,7 @@ main(int argc, char **argv)
 		verbose = MAX(verbose, 1);
 
 	for (c = 0; c < 256; c++) {
-		if (dump_all && strchr("ABeEFkKlLNOPrRSXy", c) == NULL)
+		if (dump_all && strchr("ABeEfFkKlLNOPrRSXy", c) == NULL)
 			dump_opt[c] = 1;
 		if (dump_opt[c])
 			dump_opt[c] += verbose;

--- a/cmd/zinject/zinject.c
+++ b/cmd/zinject/zinject.c
@@ -223,6 +223,7 @@ static const struct errstr errstrtable[] = {
 	{ ECHILD,	"dtl" },
 	{ EILSEQ,	"corrupt" },
 	{ ENOSYS,	"noop" },
+	{ EFAULT,	"io-prefail" },
 	{ 0, NULL },
 };
 
@@ -302,7 +303,8 @@ usage(void)
 	    "\t\tlabel.  Label injection can either be 'nvlist', 'uber',\n "
 	    "\t\t'pad1', or 'pad2'.\n"
 	    "\t\t'errno' can be 'nxio' (the default), 'io', 'dtl',\n"
-	    "\t\t'corrupt' (bit flip), or 'noop' (successfully do nothing).\n"
+	    "\t\t'corrupt' (bit flip), 'io-prefail' (unsuccessfully do\n"
+	    "\t\tnothing) or 'noop' (successfully do nothing).\n"
 	    "\t\t'frequency' is a value between 0.0001 and 100.0 that limits\n"
 	    "\t\tdevice error injection to a percentage of the IOs.\n"
 	    "\n"
@@ -993,7 +995,8 @@ main(int argc, char **argv)
 			if (error < 0) {
 				(void) fprintf(stderr, "invalid error type "
 				    "'%s': must be one of: io decompress "
-				    "decrypt nxio dtl corrupt noop\n",
+				    "decrypt nxio dtl corrupt noop "
+				    "io-prefail\n",
 				    optarg);
 				usage();
 				libzfs_fini(g_zfs);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -272,6 +272,7 @@ typedef enum {
 /* Small enough to not hog a whole line of printout in zpool(8). */
 #define	ZPROP_MAX_COMMENT	32
 #define	ZPROP_BOOLEAN_NA	2
+#define	ZPROP_BOOLEAN_INHERIT	2
 
 #define	ZPROP_VALUE		"value"
 #define	ZPROP_SOURCE		"source"

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -244,6 +244,7 @@ typedef uint64_t zio_flag_t;
 #define	ZIO_FLAG_DELEGATED	(1ULL << 31)
 #define	ZIO_FLAG_DIO_CHKSUM_ERR	(1ULL << 32)
 #define	ZIO_FLAG_PREALLOCATED	(1ULL << 33)
+#define	ZIO_FLAG_POSTREAD	(1ULL << 34)
 
 #define	ZIO_ALLOCATOR_NONE	(-1)
 #define	ZIO_HAS_ALLOCATOR(zio)	((zio)->io_allocator != ZIO_ALLOCATOR_NONE)

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2292,6 +2292,13 @@ and may need to load new metaslabs to satisfy these allocations.
 .It Sy zfs_sync_pass_rewrite Ns = Ns Sy 2 Pq uint
 Rewrite new block pointers starting in this pass.
 .
+.It Sy zfs_scrub_partial_writes Ns = Ns Sy 1 Ns | Ns 0 Pq int
+If a write to a multi-disk vdev fails, but the data is recoverable, the data is
+persisted on disk but may not be as redundant as the vdev usually ensures.
+If this tunable is set, we issue a read after such a write error to detect the
+full extent of the problem and attempt to recover from it.
+Note: This currently only works with RAID-Z and dRAID.
+.
 .It Sy zfs_trim_extent_bytes_max Ns = Ns Sy 134217728 Ns B Po 128 MiB Pc Pq uint
 Maximum size of TRIM command.
 Larger ranges will be split into chunks no larger than this value before

--- a/man/man7/vdevprops.7
+++ b/man/man7/vdevprops.7
@@ -153,9 +153,12 @@ defaults see
 A text comment up to 8192 characters long
 .It Sy bootsize
 The amount of space to reserve for the EFI system partition
-.It Sy failfast
+.It Sy failfast Ns = Ns Sy inherit Ns | Ns Sy on Ns | Ns Sy off
 If this device should propagate BIO errors back to ZFS, used to disable
 failfast.
+.Sy inherit
+causes the vdev to adopt the behavior of its parent vdev,
+recursively up the tree.
 .It Sy sit_out
 Only valid for
 .Sy RAIDZ

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -258,10 +258,15 @@ Decode and display block from an embedded block pointer specified by the
 arguments.
 .It Fl f , -file-layout
 Display the file layout of an object for the disks of a raidz vdev.
+Numeric values in the disply are hexadecimal.
 With
 .Fl H ,
 the output is in scripted mode for easy parsing, with all values
-being presented as 512 byte blocks.
+being presented as 512 byte blocks in decimal; with
+.Fl v ,
+the block type (parity or data) is displayed; with
+.Fl vv ,
+the offset into the file for each block is also printed.
 Only a single top-level raidz vdev is supported.
 .It Fl h , -history
 Display pool history similar to

--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -260,7 +260,9 @@ arguments.
 Display the file layout of an object for the disks of a raidz vdev.
 With
 .Fl H ,
-the output is in scripted mode for easy parsing.
+the output is in scripted mode for easy parsing, with all values
+being presented as 512 byte blocks.
+Only a single top-level raidz vdev is supported.
 .It Fl h , -history
 Display pool history similar to
 .Nm zpool Cm history ,

--- a/man/man8/zinject.8
+++ b/man/man8/zinject.8
@@ -223,8 +223,10 @@ for an ECHILD error,
 for an EIO error where reopening the device will succeed,
 .It Sy nxio
 for an ENXIO error where reopening the device will fail, or
+.It Sy io-prefail
+to drop the IO without executing it and return failure, or
 .It Sy noop
-to drop the IO without executing it, and return success.
+to drop the IO without executing it and return success.
 .El
 .Pp
 For EIO and ENXIO, the "failed" reads or writes still occur.

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -920,8 +920,14 @@ vdev_disk_io_rw(zio_t *zio)
 		return (SET_ERROR(EIO));
 	}
 
+	vdev_t *iter = v;
+	while (iter != NULL && iter->vdev_failfast == ZPROP_BOOLEAN_INHERIT)
+		iter = iter->vdev_parent;
+
+	boolean_t failfast = iter ? iter->vdev_failfast == 1 :
+	    vdev_prop_default_numeric(VDEV_PROP_FAILFAST);
 	if (!(zio->io_flags & (ZIO_FLAG_IO_RETRY | ZIO_FLAG_TRYHARD)) &&
-	    v->vdev_failfast == B_TRUE) {
+	    failfast) {
 		bio_set_flags_failfast(bdev, &flags, zfs_vdev_failfast_mask & 1,
 		    zfs_vdev_failfast_mask & 2, zfs_vdev_failfast_mask & 4);
 	}

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -319,10 +319,16 @@ vdev_prop_init(void)
 		{ "on",		1},
 		{ NULL }
 	};
+	static const zprop_index_t boolean_inherit_table[] = {
+		{ "off",	0},
+		{ "on",		1},
+		{ "inherit",	ZPROP_BOOLEAN_INHERIT},
+		{ NULL }
+	};
 	static const zprop_index_t boolean_na_table[] = {
 		{ "off",	0},
 		{ "on",		1},
-		{ "-",		2},	/* ZPROP_BOOLEAN_NA */
+		{ "-",		ZPROP_BOOLEAN_NA},
 		{ NULL }
 	};
 
@@ -479,8 +485,8 @@ vdev_prop_init(void)
 
 	/* default index properties */
 	zprop_register_index(VDEV_PROP_FAILFAST, "failfast", B_TRUE,
-	    PROP_DEFAULT, ZFS_TYPE_VDEV, "on | off", "FAILFAST", boolean_table,
-	    sfeatures);
+	    PROP_DEFAULT, ZFS_TYPE_VDEV, "on | off | inherit", "FAILFAST",
+	    boolean_inherit_table, sfeatures);
 
 	/* hidden properties */
 	zprop_register_hidden(VDEV_PROP_NAME, "name", PROP_TYPE_STRING,

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1064,6 +1064,11 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 	if (top_level && (ops == &vdev_raidz_ops || ops == &vdev_draid_ops))
 		vd->vdev_autosit =
 		    vdev_prop_default_numeric(VDEV_PROP_AUTOSIT);
+	if (ops == &vdev_root_ops)
+		vd->vdev_failfast =
+		    vdev_prop_default_numeric(VDEV_PROP_FAILFAST);
+	else
+		vd->vdev_failfast = ZPROP_BOOLEAN_INHERIT;
 
 	/*
 	 * Add ourselves to the parent's list of children.
@@ -3799,10 +3804,9 @@ vdev_load(vdev_t *vd)
 		    vdev_prop_to_name(VDEV_PROP_FAILFAST), sizeof (failfast),
 		    1, &failfast);
 		if (error == 0) {
-			vd->vdev_failfast = failfast & 1;
+			vd->vdev_failfast = failfast;
 		} else if (error == ENOENT) {
-			vd->vdev_failfast = vdev_prop_default_numeric(
-			    VDEV_PROP_FAILFAST);
+			vd->vdev_failfast = ZPROP_BOOLEAN_INHERIT;
 		} else {
 			vdev_dbgmsg(vd,
 			    "vdev_load: zap_lookup(top_zap=%llu) "
@@ -6080,11 +6084,14 @@ vdev_prop_set(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				error = spa_vdev_alloc(spa, vdev_guid);
 			break;
 		case VDEV_PROP_FAILFAST:
-			if (nvpair_value_uint64(elem, &intval) != 0) {
+			if (nvpair_value_uint64(elem, &intval) != 0 ||
+			    intval > ZPROP_BOOLEAN_INHERIT ||
+			    (intval == ZPROP_BOOLEAN_INHERIT &&
+			    vd->vdev_ops == &vdev_root_ops)) {
 				error = EINVAL;
 				break;
 			}
-			vd->vdev_failfast = intval & 1;
+			vd->vdev_failfast = intval;
 			break;
 		case VDEV_PROP_SIT_OUT:
 			/* Only expose this for a draid or raidz leaf */
@@ -6531,18 +6538,23 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 				break;
 			case VDEV_PROP_FAILFAST:
 				src = ZPROP_SRC_LOCAL;
-				strval = NULL;
 
 				err = zap_lookup(mos, objid, nvpair_name(elem),
 				    sizeof (uint64_t), 1, &intval);
 				if (err == ENOENT) {
-					intval = vdev_prop_default_numeric(
-					    prop);
+					if (vd->vdev_ops == &vdev_root_ops)
+						intval =
+						    vdev_prop_default_numeric(
+						    prop);
+					else
+						intval = ZPROP_BOOLEAN_INHERIT;
 					err = 0;
 				} else if (err) {
 					break;
 				}
-				if (intval == vdev_prop_default_numeric(prop))
+				if (intval == ZPROP_BOOLEAN_INHERIT ||
+				    (vd->vdev_ops == &vdev_root_ops &&
+				    intval == 1))
 					src = ZPROP_SRC_DEFAULT;
 
 				vdev_prop_add_list(outnvl, propname, strval,

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -405,6 +405,16 @@ static unsigned long raidz_io_aggregate_rows = 4;
  */
 static int zfs_scrub_after_expand = 1;
 
+/*
+ * If there are errors when writing, but few enough that the data is
+ * recoverable, then ZFS used to silently move on, leaving the data not 100%
+ * redundant. If this tunable is set, we issue a read after that case occurs,
+ * allowing the normal error recovery process to handle it.
+ *
+ * NOTE: Currently applies only to raidz and draid.
+ */
+static int zfs_scrub_partial_writes = 1;
+
 static void
 vdev_raidz_row_free(raidz_row_t *rr)
 {
@@ -3612,6 +3622,7 @@ vdev_raidz_io_done_write_impl(zio_t *zio, raidz_row_t *rr)
 {
 	int normal_errors = 0;
 	int shadow_errors = 0;
+	int retryable_errors = 0;
 
 	ASSERT3U(rr->rr_missingparity, <=, rr->rr_firstdatacol);
 	ASSERT3U(rr->rr_missingdata, <=, rr->rr_cols - rr->rr_firstdatacol);
@@ -3627,6 +3638,11 @@ vdev_raidz_io_done_write_impl(zio_t *zio, raidz_row_t *rr)
 		if (rc->rc_shadow_error != 0) {
 			ASSERT(rc->rc_shadow_error != ECKSUM);
 			shadow_errors++;
+		}
+		if (rc->rc_error || rc->rc_shadow_error) {
+			vdev_t *cvd = zio->io_vd->vdev_child[rc->rc_devidx];
+			if (!(vdev_is_dead(cvd) || cvd->vdev_cant_write))
+				retryable_errors++;
 		}
 	}
 
@@ -3647,6 +3663,8 @@ vdev_raidz_io_done_write_impl(zio_t *zio, raidz_row_t *rr)
 	    shadow_errors > rr->rr_firstdatacol) {
 		zio->io_error = zio_worst_error(zio->io_error,
 		    vdev_raidz_worst_error(rr));
+	} else if (retryable_errors && zfs_scrub_partial_writes) {
+		zio->io_flags |= ZIO_FLAG_POSTREAD;
 	}
 }
 
@@ -5496,6 +5514,9 @@ ZFS_MODULE_PARAM(zfs_vdev, raidz_, io_aggregate_rows, ULONG, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, scrub_after_expand, INT, ZMOD_RW,
 	"For expanded RAIDZ, automatically start a pool scrub when expansion "
 	"completes");
+ZFS_MODULE_PARAM(zfs, zfs_, scrub_partial_writes, INT, ZMOD_RW,
+	"Issue reads after writes with recoverable failures to ensure "
+	"integrity");
 ZFS_MODULE_PARAM(zfs_vdev, vdev_, read_sit_out_secs, ULONG, ZMOD_RW,
 	"Raidz/draid slow disk sit out time period in seconds");
 ZFS_MODULE_PARAM(zfs_vdev, vdev_, raidz_outlier_check_interval_ms, ULONG,

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1850,10 +1850,10 @@ zio_vdev_child_io(zio_t *pio, blkptr_t *bp, vdev_t *vd, uint64_t offset,
 	 * have already processed the original allocating I/O.
 	 */
 	if (flags & ZIO_FLAG_IO_ALLOCATING &&
-	    (vd != vd->vdev_top || (flags & ZIO_FLAG_IO_RETRY))) {
+	    (vd != vd->vdev_top || (flags & ZIO_FLAG_IO_RETRY)) &&
+	    type == ZIO_TYPE_WRITE) {
 		ASSERT(pio->io_metaslab_class != NULL);
 		ASSERT(pio->io_metaslab_class->mc_alloc_throttle_enabled);
-		ASSERT(type == ZIO_TYPE_WRITE);
 		ASSERT(priority == ZIO_PRIORITY_ASYNC_WRITE);
 		ASSERT(!(flags & ZIO_FLAG_IO_REPAIR));
 		ASSERT(!(pio->io_flags & ZIO_FLAG_IO_REWRITE) ||
@@ -4767,11 +4767,17 @@ zio_vdev_io_start(zio_t *zio)
 		}
 		zio->io_delay = gethrtime();
 
-		if (zio_handle_device_injection(vd, zio, ENOSYS) != 0) {
+		int error = zio_handle_device_injections(vd, zio, ENOSYS,
+		    EFAULT);
+		if (error == ENOSYS || (error == EFAULT &&
+		    !(zio->io_flags & ZIO_FLAG_IO_REPAIR))) {
 			/*
 			 * "no-op" injections return success, but do no actual
-			 * work. Just return it.
+			 * work. Just return it. "io-prefail" injections are
+			 * similar, but don't return success.
 			 */
+			if (error == EFAULT)
+				zio->io_error = EIO;
 			zio_delay_interrupt(zio);
 			return (NULL);
 		}
@@ -5490,6 +5496,12 @@ zio_dva_throttle_done(zio_t *zio)
 	}
 }
 
+static void
+zio_done_postread_done(zio_t *zio)
+{
+	abd_free(zio->io_abd);
+}
+
 static zio_t *
 zio_done(zio_t *zio)
 {
@@ -5803,6 +5815,24 @@ zio_done(zio_t *zio)
 		zcr->zcr_next = NULL;
 		zcr->zcr_finish(zcr, NULL);
 		zfs_ereport_free_checksum(zcr);
+	}
+
+	if (zio->io_flags & ZIO_FLAG_POSTREAD) {
+		ASSERT3U(zio->io_type, ==, ZIO_TYPE_WRITE);
+		zl = NULL;
+		zio_t *pio = zio_walk_parents(zio, &zl);
+		blkptr_t *bp = zio->io_bp;
+		abd_t *abd = abd_alloc_for_io(BP_GET_PSIZE(bp), B_FALSE);
+		zio_priority_t prio = zio->io_priority ==
+		    ZIO_PRIORITY_SYNC_WRITE ? ZIO_PRIORITY_SYNC_READ :
+		    ZIO_PRIORITY_SCRUB;
+		zio_t *cio = zio_vdev_child_io(pio, zio->io_bp, zio->io_vd,
+		    zio->io_offset, abd, zio->io_size, ZIO_TYPE_READ, prio,
+		    ZIO_FLAG_SCRUB | ZIO_FLAG_RAW | ZIO_FLAG_CANFAIL |
+		    ZIO_FLAG_RESILVER | ZIO_FLAG_DONT_PROPAGATE,
+		    zio_done_postread_done, NULL);
+		cio->io_flags &= ~ZIO_FLAG_IO_ALLOCATING;
+		zio_nowait(cio);
 	}
 
 	/*

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -876,7 +876,7 @@ tags = ['functional', 'redacted_send']
 tests = ['raidz_001_neg', 'raidz_002_pos', 'raidz_expand_001_pos',
     'raidz_expand_002_pos', 'raidz_expand_003_neg', 'raidz_expand_003_pos',
     'raidz_expand_004_pos', 'raidz_expand_005_pos', 'raidz_expand_006_neg',
-    'raidz_expand_007_neg']
+    'raidz_expand_007_neg', 'raidz_zinject']
 tags = ['functional', 'raidz']
 timeout = 1200
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -545,8 +545,8 @@ tags = ['functional', 'cli_root', 'zpool_scrub']
 
 [tests/functional/cli_root/zpool_set]
 tests = ['zpool_set_001_pos', 'zpool_set_002_neg', 'zpool_set_003_neg',
-    'zpool_set_ashift', 'zpool_set_features', 'vdev_set_001_pos',
-    'user_property_001_pos', 'user_property_002_neg',
+    'zpool_set_ashift', 'zpool_set_features', 'zpool_set_inherit',
+    'vdev_set_001_pos', 'user_property_001_pos', 'user_property_002_neg',
     'zpool_set_clear_userprop']
 tags = ['functional', 'cli_root', 'zpool_set']
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -169,8 +169,10 @@ tests = ['zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos', 'zdb_005_pos',
     'zdb_006_pos', 'zdb_args_neg', 'zdb_args_pos',
     'zdb_block_size_histogram', 'zdb_checksum', 'zdb_decompress',
     'zdb_display_block', 'zdb_encrypted', 'zdb_label_checksum',
-    'zdb_object_range_neg', 'zdb_object_range_pos', 'zdb_objset_id',
-    'zdb_decompress_zstd', 'zdb_recover', 'zdb_recover_2', 'zdb_backup']
+    'zdb_file_layout_001', 'zdb_file_layout_002', 'zdb_file_layout_003',
+    'zdb_file_layout_neg', 'zdb_object_range_neg', 'zdb_object_range_pos',
+    'zdb_objset_id', 'zdb_decompress_zstd', 'zdb_recover', 'zdb_recover_2',
+    'zdb_backup']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zdb']

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -348,7 +348,7 @@ timeout = 600
 
 [tests/functional/cli_root/zpool_set]
 tests = ['zpool_set_001_pos', 'zpool_set_002_neg', 'zpool_set_003_neg',
-    'zpool_set_ashift', 'zpool_set_features']
+    'zpool_set_ashift', 'zpool_set_features', 'zpool_set_inherit']
 tags = ['functional', 'cli_root', 'zpool_set']
 
 [tests/functional/cli_root/zpool_split]

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2004,6 +2004,26 @@ function wait_sit_out #pool vdev timeout
 
 #
 # Check the output of 'zpool status -v <pool>',
+# and to see if the counts of <device> contain the <regex> specified.
+#
+# Return 0 is contain, 1 otherwise
+#
+function check_pool_device # pool device regex <verbose>
+{
+	typeset pool=$1
+	typeset device=$2
+	typeset regex=$3
+	typeset verbose=${4:-false}
+
+	scan=$(zpool status -v "$pool" 2>/dev/null | grep $device)
+	if [[ $verbose == true ]]; then
+		log_note $scan
+	fi
+	echo $scan | grep -qi "$regex"
+}
+
+#
+# Check the output of 'zpool status -v <pool>',
 # and to see if the content of <token> contain the <keyword> specified.
 #
 # Return 0 is contain, 1 otherwise

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1253,6 +1253,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_set/zpool_set_002_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_003_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_ashift.ksh \
+	functional/cli_root/zpool_set/zpool_set_inherit.ksh \
 	functional/cli_root/zpool_set/user_property_001_pos.ksh \
 	functional/cli_root/zpool_set/user_property_002_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_features.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -638,6 +638,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zdb/zdb_display_block.ksh \
 	functional/cli_root/zdb/zdb_encrypted.ksh \
 	functional/cli_root/zdb/zdb_label_checksum.ksh \
+	functional/cli_root/zdb/zdb_file_layout_001.ksh \
+	functional/cli_root/zdb/zdb_file_layout_002.ksh \
+	functional/cli_root/zdb/zdb_file_layout_003.ksh \
+	functional/cli_root/zdb/zdb_file_layout_neg.ksh \
 	functional/cli_root/zdb/zdb_object_range_neg.ksh \
 	functional/cli_root/zdb/zdb_object_range_pos.ksh \
 	functional/cli_root/zdb/zdb_objset_id.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1804,6 +1804,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/raidz/raidz_expand_005_pos.ksh \
 	functional/raidz/raidz_expand_006_neg.ksh \
 	functional/raidz/raidz_expand_007_neg.ksh \
+	functional/raidz/raidz_zinject.ksh \
 	functional/raidz/setup.ksh \
 	functional/redacted_send/cleanup.ksh \
 	functional/redacted_send/redacted_compressed.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_001.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_001.ksh
@@ -1,0 +1,78 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -fHv <dataset> <objnum> will display block
+# layouts for the object.
+#
+# Strategery:
+# 1. Create a RAIDZ1 pool, set compression to none
+# 2. Create a file filled with random data
+# 3. Get the inode number of the file
+# 4. Run zdb -fHv <pool>/ <inum> & extract file
+# 5. Compare real file and extracted file.
+
+DATA=/$TESTPOOL1/random.bin
+BLOCKS=$(( $RANDOM % 16 ))
+COMPARE=/tmp/compare.$$
+
+function cleanup
+{
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file?.bin $COMPARE
+}
+
+log_assert "Verify zdb -fHv displays correct offsets"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+for file in 1 2 3 4 5
+do
+    rm -f $TESTDIR/file${file}.bin
+    touch $TESTDIR/file${file}.bin
+    log_must truncate -s 128m $TESTDIR/file${file}.bin
+done
+
+log_must zpool create -O compression=off -O recordsize=16K $TESTPOOL1 raidz1 $TESTDIR/file[12345].bin
+zfs get compression,recordsize $TESTPOOL1
+# 2. Create a file with random data
+log_must rm -f $DATA
+log_must dd if=/dev/urandom of=${DATA} bs=16k count=${BLOCKS} > /dev/null 2>&1
+log_must zpool sync $TESTPOOL1
+
+# 3. Get the inode number of the file
+INUM=$(ls -li $DATA | cut -f1 -d ' ')
+
+# 4. Extract the contents of the file using dd
+rm -f $COMPARE
+log_must touch ${COMPARE}
+log_must zdb -fHv $TESTPOOL1/ ${INUM} |  grep 'D.$' |
+    while read file offset count rest
+    do
+	log_must sh -c "dd if=$TESTDIR/${file} bs=512 skip=${offset} count=${count} >> ${COMPARE}"
+    done
+
+# 5. Compare files
+log_must cmp  ${COMPARE} ${DATA}
+
+log_pass "'zdb -fHv' works as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_002.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_002.ksh
@@ -1,0 +1,78 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -fHv <dataset> <objnum> will display block
+# layouts for the object.
+#
+# Strategery:
+# 1. Create a RAIDZ2 pool, set compression to none
+# 2. Create a file filled with random data
+# 3. Get the inode number of the file
+# 4. Run zdb -fHv <pool>/ <inum> & extract file
+# 5. Compare real file and extracted file.
+
+DATA=/$TESTPOOL1/random.bin
+BLOCKS=$(( $RANDOM % 16 ))
+COMPARE=/tmp/compare.$$
+
+function cleanup
+{
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file?.bin $COMPARE
+}
+
+log_assert "Verify zdb -fHv displays correct offsets"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+for file in 1 2 3 4 5 6
+do
+    rm -f $TESTDIR/file${file}.bin
+    touch $TESTDIR/file${file}.bin
+    log_must truncate -s 128m $TESTDIR/file${file}.bin
+done
+
+log_must zpool create -O compression=off -O recordsize=16K $TESTPOOL1 raidz2 $TESTDIR/file[123456].bin
+zfs get compression,recordsize $TESTPOOL1
+# 2. Create a file with random data
+log_must rm -f $DATA
+log_must dd if=/dev/urandom of=${DATA} bs=16k count=${BLOCKS} > /dev/null 2>&1
+log_must zpool sync $TESTPOOL1
+
+# 3. Get the inode number of the file
+INUM=$(ls -li $DATA | cut -f1 -d ' ')
+
+# 4. Extract the contents of the file using dd
+rm -f $COMPARE
+log_must touch ${COMPARE}
+log_must zdb -fHv $TESTPOOL1/ ${INUM} |  grep 'D.$' |
+    while read file offset count rest
+    do
+	log_must sh -c "dd if=$TESTDIR/${file} bs=512 skip=${offset} count=${count} >> ${COMPARE}"
+    done
+
+# 5. Compare files
+log_must cmp  ${COMPARE} ${DATA}
+
+log_pass "'zdb -fHv' works as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_003.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_003.ksh
@@ -1,0 +1,78 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# zdb -fHv <dataset> <objnum> will display block
+# layouts for the object.
+#
+# Strategery:
+# 1. Create a RAIDZ3 pool, set compression to none
+# 2. Create a file filled with random data
+# 3. Get the inode number of the file
+# 4. Run zdb -fHv <pool>/ <inum> & extract file
+# 5. Compare real file and extracted file.
+
+DATA=/$TESTPOOL1/random.bin
+BLOCKS=$(( $RANDOM % 16 ))
+COMPARE=/tmp/compare.$$
+
+function cleanup
+{
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file?.bin $COMPARE
+}
+
+log_assert "Verify zdb -fHv displays correct offsets"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+for file in 1 2 3 4 5 6 7
+do
+    rm -f $TESTDIR/file${file}.bin
+    touch $TESTDIR/file${file}.bin
+    log_must truncate -s 128m $TESTDIR/file${file}.bin
+done
+
+log_must zpool create -O compression=off -O recordsize=16K $TESTPOOL1 raidz3 $TESTDIR/file[123456].bin
+zfs get compression,recordsize $TESTPOOL1
+# 2. Create a file with random data
+log_must rm -f $DATA
+log_must dd if=/dev/urandom of=${DATA} bs=16k count=${BLOCKS} > /dev/null 2>&1
+log_must zpool sync $TESTPOOL1
+
+# 3. Get the inode number of the file
+INUM=$(ls -li $DATA | cut -f1 -d ' ')
+
+# 4. Extract the contents of the file using dd
+rm -f $COMPARE
+log_must touch ${COMPARE}
+log_must zdb -fHv $TESTPOOL1/ ${INUM} |  grep 'D.$' |
+    while read file offset count rest
+    do
+	log_must sh -c "dd if=$TESTDIR/${file} bs=512 skip=${offset} count=${count} >> ${COMPARE}"
+    done
+
+# 5. Compare files
+log_must cmp  ${COMPARE} ${DATA}
+
+log_pass "'zdb -fHv' works as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_file_layout_neg.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 by Datto, Inc. All rights reserved.
+# Copyright (c) 2026, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# Ensure zdb -f only works on raidz
+#
+# Strategery:
+# 1. Create a pool with one disk
+# 2. Create a file
+# 3. Get the inode number of the file
+# 4. Run zdb -f
+# 5. Confirm failure status
+
+function cleanup
+{
+    destroy_pool $TESTPOOL1
+    rm -f $TESTDIR/file1.bin
+}
+
+log_assert "Verify zdb -f fails on non-raidz pool"
+log_onexit cleanup
+
+# 1. Create a RAIDZ1 pool
+log_must mkdir -p $TESTDIR
+touch $TESTDIR/file1.bin
+log_must truncate -s 128m $TESTDIR/file1.bin
+log_must zpool create -f $TESTPOOL1 $TESTDIR/file1.bin
+
+# 2. Create a file
+log_must touch /$TESTPOOL1/file.txt
+
+# 3. Get the inode number of the file
+INUM=$(ls -li /$TESTDIR/file1.txt | cut -f1 -d ' ')
+
+# 4. Run zdb -f
+log_mustnot zdb -f $TESTDIR/ $INUM
+
+log_pass "'zdb -f' fails on non-raidz as expected."

--- a/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_args.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zinject/zinject_args.ksh
@@ -48,7 +48,7 @@ function cleanup
 
 function test_device_fault
 {
-	typeset -a errno=("io" "decompress" "decrypt" "nxio" "dtl" "corrupt" "noop")
+	typeset -a errno=("io" "decompress" "decrypt" "nxio" "dtl" "corrupt" "noop" "io-prefail")
 	for e in ${errno[@]}; do
 		log_must eval \
 		    "zinject -d $DISK1 -e $e -T read -f 0.001 $TESTPOOL"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_inherit.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_inherit.ksh
@@ -1,0 +1,115 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2026, Klara, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# zpool set can set the failfast property to 'inherit'
+#
+# STRATEGY:
+# 1. Create a pool
+# 2. Verify that we can set 'failfast' to various values, including inherit
+# 3. Verify that the root vdev cannot be set to inherit
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV1 $FILEVDEV2 $FILEVDEV3
+}
+
+function get_failfast
+{
+	zpool get -H -o value failfast $TESTPOOL1 $@
+}
+
+log_onexit cleanup
+
+log_assert "zpool set can configure 'failfast' property to inherit"
+FILEVDEV1="$TEST_BASE_DIR/zpool_set_inherit1.$$.dat"
+FILEVDEV2="$TEST_BASE_DIR/zpool_set_inherit2.$$.dat"
+FILEVDEV3="$TEST_BASE_DIR/zpool_set_inherit3.$$.dat"
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV1
+log_must truncate -s $MINVDEVSIZE $FILEVDEV2
+log_must truncate -s $MINVDEVSIZE $FILEVDEV3
+
+log_must zpool create -f $TESTPOOL1 $FILEVDEV1 mirror $FILEVDEV2 $FILEVDEV3
+failfast=$(get_failfast $FILEVDEV1)
+[[ "$failfast" == "inherit" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=on $TESTPOOL1 $FILEVDEV1
+failfast=$(get_failfast $FILEVDEV1)
+[[ "$failfast" == "on" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=off $TESTPOOL1 $FILEVDEV1
+failfast=$(get_failfast $FILEVDEV1)
+[[ "$failfast" == "off" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=inherit $TESTPOOL1 $FILEVDEV1
+
+failfast=$(get_failfast $FILEVDEV2)
+[[ "$failfast" == "inherit" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=on $TESTPOOL1 $FILEVDEV2
+failfast=$(get_failfast $FILEVDEV2)
+[[ "$failfast" == "on" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=off $TESTPOOL1 $FILEVDEV2
+failfast=$(get_failfast $FILEVDEV2)
+[[ "$failfast" == "off" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=inherit $TESTPOOL1 $FILEVDEV2
+
+failfast=$(get_failfast mirror-1)
+[[ "$failfast" == "inherit" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=on $TESTPOOL1 mirror-1
+failfast=$(get_failfast mirror-1)
+[[ "$failfast" == "on" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=off $TESTPOOL1 mirror-1
+failfast=$(get_failfast mirror-1)
+[[ "$failfast" == "off" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=inherit $TESTPOOL1 mirror-1
+
+failfast=$(get_failfast root)
+[[ "$failfast" == "on" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_must zpool set failfast=off $TESTPOOL1 root
+failfast=$(get_failfast root)
+[[ "$failfast" == "off" ]] || log_fail "incorrect failfast value: $failfast"
+
+log_mustnot zpool set failfast=inherit $TESTPOOL1 root
+
+
+log_pass "zpool set can configure 'failfast' property to inherit"

--- a/tests/zfs-tests/tests/functional/raidz/raidz_zinject.ksh
+++ b/tests/zfs-tests/tests/functional/raidz/raidz_zinject.ksh
@@ -1,0 +1,94 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026, Klara Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	Inject an io-prefail error on a child of a raidz device, then write
+#	some data and verify that the pool encountered errors.
+#
+
+function cleanup
+{
+	log_pos zpool status $TESTPOOL
+
+	log_must zinject -c all
+
+	poolexists "$TESTPOOL" && log_must_busy zpool destroy "$TESTPOOL"
+
+	for i in {1..$devs}; do
+		log_must rm -f "$TEST_BASE_DIR/dev-$i"
+	done
+
+}
+
+log_onexit cleanup
+
+typeset -r devs=6
+typeset -r dev_size_mb=128
+
+typeset -a disks
+
+# Disk files which will be used by pool
+for i in {1..$devs}; do
+	device=$TEST_BASE_DIR/dev-$i
+	log_must truncate -s ${dev_size_mb}M $device
+	disks[${#disks[*]}+1]=$device
+done
+
+function run_test
+{
+	log_must zpool create -f -o cachefile=none -O recordsize=16k $TESTPOOL raidz1 ${disks[@]}
+
+	log_must zinject -d $TEST_BASE_DIR/dev-1 -e io-prefail -T write -f 25 $TESTPOOL
+
+	log_must file_write -o create -f /$TESTPOOL/file -b 128k -c 1000 -d R
+	log_must zpool sync $TESTPOOL
+	log_pos check_pool_status $TESTPOOL "errors" "No known data errors" || return 1
+	log_pos check_pool_status $TESTPOOL "status" "One or more" || return 1
+
+	log_must zinject -c all
+	log_must zpool export -f $TESTPOOL
+	log_must rm $TEST_BASE_DIR/dev-2
+	log_must zpool import -d $TEST_BASE_DIR $TESTPOOL
+	log_must zpool scrub $TESTPOOL
+	log_must zpool wait -t scrub $TESTPOOL
+	log_pos check_pool_status $TESTPOOL "errors" "No known data" || return 1
+	log_pos check_pool_device $TESTPOOL "dev-1" "ONLINE.* 0$" || return 1
+}
+
+i=0
+while [[ $i -lt 3 ]]; do
+	run_test && log_pass "raidz handles partial write failure."
+	log_must zinject -c all
+	log_must zpool destroy $TESTPOOL
+	log_must truncate -s ${dev_size_mb}M $TEST_BASE_DIR/dev-2
+	i=$((i + 1))
+done
+
+log_fail "raidz does not handle partial write failure."


### PR DESCRIPTION
Hello,

Here is a set of patches that we discussed for the next update of 2.3.2 for Wasabi. This patchset includes tweaks to the zdb file layout tool, as well as fixes for the errors <= nparity issue and updates to the vdev failfast property.